### PR TITLE
VPCの作成とプロジェクトの初期構成の作成

### DIFF
--- a/modules/aws/bastion/main.tf
+++ b/modules/aws/bastion/main.tf
@@ -1,0 +1,94 @@
+resource "aws_security_group" "bastion" {
+  name = "${terraform.workspace}-${lookup(
+    var.bastion,
+    "${terraform.workspace}.name",
+    var.bastion["default.name"]
+  )}"
+  description = "Security Group to ${lookup(
+    var.bastion,
+    "${terraform.workspace}.name",
+    var.bastion["default.name"]
+  )}"
+  vpc_id = var.vpc["vpc_id"]
+
+  tags = {
+    Name = "${terraform.workspace}-${lookup(
+      var.bastion,
+      "${terraform.workspace}.name",
+      var.bastion["default.name"]
+    )}"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_key_pair" "ssh_key_pair" {
+  public_key = file(var.ssh_public_key_path)
+  key_name   = "${terraform.workspace}-love-psychology-ssh-key"
+}
+
+resource "aws_security_group_rule" "ssh_from_workplace" {
+  security_group_id = aws_security_group.bastion.id
+  type              = "ingress"
+  from_port         = "22"
+  to_port           = "22"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_instance" "bastion_1a" {
+  ami = lookup(
+    var.bastion,
+    "${terraform.workspace}.ami",
+    var.bastion["default.ami"]
+  )
+  associate_public_ip_address = true
+  instance_type = lookup(
+    var.bastion,
+    "${terraform.workspace}.instance_type",
+    var.bastion["default.instance_type"]
+  )
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = lookup(
+      var.bastion,
+      "${terraform.workspace}.volume_type",
+      var.bastion["default.volume_type"]
+    )
+    volume_size = lookup(
+      var.bastion,
+      "${terraform.workspace}.volume_size",
+      var.bastion["default.volume_size"]
+    )
+  }
+
+  key_name               = aws_key_pair.ssh_key_pair.id
+  subnet_id              = var.vpc["subnet_public_1a_id"]
+  vpc_security_group_ids = [aws_security_group.bastion.id]
+
+  tags = {
+    Name = "${terraform.workspace}-${lookup(
+      var.bastion,
+      "${terraform.workspace}.name",
+      var.bastion["default.name"]
+    )}-1a"
+  }
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "aws_eip" "bastion_ip_1a" {
+  instance = aws_instance.bastion_1a.id
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-bastion-1a"
+  }
+}

--- a/modules/aws/bastion/output.tf
+++ b/modules/aws/bastion/output.tf
@@ -1,0 +1,6 @@
+output "bastion" {
+  value = {
+    "bastion_security_id" = aws_security_group.bastion.id
+    "key_pair_id"         = aws_key_pair.ssh_key_pair.id
+  }
+}

--- a/modules/aws/bastion/sample-instance.tf
+++ b/modules/aws/bastion/sample-instance.tf
@@ -1,0 +1,50 @@
+// TODO このファイルは動作確認用なので不要になったタイミングで削除する
+resource "aws_security_group" "sample" {
+  name        = "${terraform.workspace}-sample"
+  description = "Security Group sample"
+  vpc_id      = var.vpc["vpc_id"]
+
+  tags = {
+    Name = "${terraform.workspace}-sample"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "ssh_from_bastion" {
+  security_group_id        = aws_security_group.sample.id
+  type                     = "ingress"
+  from_port                = "22"
+  to_port                  = "22"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+}
+
+resource "aws_instance" "sample_1a" {
+  ami = "ami-011facbea5ec0363b"
+
+  instance_type = "t3.micro"
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = "gp2"
+    volume_size = "30"
+  }
+
+  key_name               = aws_key_pair.ssh_key_pair.id
+  subnet_id              = var.vpc["subnet_private_1a_id"]
+  vpc_security_group_ids = [aws_security_group.sample.id]
+
+  tags = {
+    Name = "${terraform.workspace}-sample-1a"
+  }
+
+  lifecycle {
+    ignore_changes = all
+  }
+}

--- a/modules/aws/bastion/variable.tf
+++ b/modules/aws/bastion/variable.tf
@@ -1,0 +1,24 @@
+variable "bastion" {
+  type = map(string)
+
+  default = {
+    "default.name"          = "love-psychology-bastion"
+    "default.ami"           = "ami-011facbea5ec0363b"
+    "default.instance_type" = "t3.micro"
+    "default.volume_type"   = "gp2"
+    "default.volume_size"   = "8"
+  }
+}
+
+variable "vpc" {
+  type = map(string)
+
+  default = {}
+}
+
+// TODO AWSアカウントがステージング本番で違うので後で環境変数として渡すように改修する
+variable "ssh_public_key_path" {
+  type = string
+
+  default = "~/.ssh/stg_love_psychology_aws.pem.pub"
+}

--- a/modules/aws/bastion/versions.tf
+++ b/modules/aws/bastion/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -7,3 +7,56 @@ resource "aws_vpc" "vpc" {
     Name = lookup(var.vpc, "${terraform.workspace}.name", var.vpc["default.name"])
   }
 }
+
+data "aws_iam_policy_document" "vpc_flow_log_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "vpc_flow_log_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "vpc_flow_log_role" {
+  name               = "${terraform.workspace}-love-psychology-vpc-flow-log-role"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_trust_relationship.json
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs_role" {
+  role   = aws_iam_role.vpc_flow_log_role.name
+  policy = data.aws_iam_policy_document.vpc_flow_log_policy.json
+}
+
+resource "aws_cloudwatch_log_group" "vpc_flow_log" {
+  name              = "${terraform.workspace}-love-psychology-vpc-flow-log"
+  retention_in_days = 30
+}
+
+resource "aws_flow_log" "vpc_flow_log" {
+  iam_role_arn    = aws_iam_role.vpc_flow_log_role.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_log.arn
+  traffic_type    = "REJECT"
+  vpc_id          = aws_vpc.vpc.id
+}

--- a/modules/aws/vpc/nat-instance.tf
+++ b/modules/aws/vpc/nat-instance.tf
@@ -1,0 +1,152 @@
+resource "aws_security_group" "nat_instance" {
+  name = lookup(
+    var.nat_instance,
+    "${terraform.workspace}.name",
+    var.nat_instance["default.name"]
+  )
+  description = "Security Group to ${lookup(
+    var.nat_instance,
+    "${terraform.workspace}.name",
+    var.nat_instance["default.name"]
+  )}"
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = lookup(
+      var.nat_instance,
+      "${terraform.workspace}.name",
+      var.nat_instance["default.name"]
+    )
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "ssh_from_vpc_to_nat_instance" {
+  security_group_id = aws_security_group.nat_instance.id
+  type              = "ingress"
+  from_port         = "22"
+  to_port           = "22"
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.vpc.cidr_block]
+}
+
+resource "aws_security_group_rule" "http_from_vpc_to_nat_instance" {
+  security_group_id = aws_security_group.nat_instance.id
+  type              = "ingress"
+  from_port         = "80"
+  to_port           = "80"
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.vpc.cidr_block]
+}
+
+resource "aws_security_group_rule" "https_from_vpc_to_nat_instance" {
+  security_group_id = aws_security_group.nat_instance.id
+  type              = "ingress"
+  from_port         = "443"
+  to_port           = "443"
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.vpc.cidr_block]
+}
+
+resource "aws_key_pair" "nat_ssh_key_pair" {
+  public_key = file(var.ssh_public_key_path)
+  key_name   = "${terraform.workspace}-love-psychology-nat-ssh-key"
+}
+
+data "aws_iam_policy_document" "nat_instance_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "nat_instance_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:PutMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+      "ec2:DescribeTags",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "nat_instance_role" {
+  name               = "${terraform.workspace}-love-psychology-nat-instance-default-role"
+  assume_role_policy = data.aws_iam_policy_document.nat_instance_trust_relationship.json
+}
+
+resource "aws_iam_role_policy" "nat_instance_role_policy" {
+  name   = "${terraform.workspace}-love-psychology-nat-instance-role-policy"
+  role   = aws_iam_role.nat_instance_role.id
+  policy = data.aws_iam_policy_document.nat_instance_policy.json
+}
+
+resource "aws_iam_instance_profile" "nat_instance_profile" {
+  name = "${terraform.workspace}-love-psychology-nat-instance-profile"
+  role = aws_iam_role.nat_instance_role.name
+}
+
+resource "aws_instance" "nat_instance_1c" {
+  ami = lookup(
+    var.nat_instance,
+    "${terraform.workspace}.ami",
+    var.nat_instance["default.ami"]
+  )
+  associate_public_ip_address = true
+  instance_type = lookup(
+    var.nat_instance,
+    "${terraform.workspace}.instance_type",
+    var.nat_instance["default.instance_type"]
+  )
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = lookup(
+      var.nat_instance,
+      "${terraform.workspace}.volume_type",
+      var.nat_instance["default.volume_type"]
+    )
+    volume_size = lookup(
+      var.nat_instance,
+      "${terraform.workspace}.volume_size",
+      var.nat_instance["default.volume_size"]
+    )
+  }
+
+  key_name               = aws_key_pair.nat_ssh_key_pair.id
+  subnet_id              = aws_subnet.public_1c.id
+  vpc_security_group_ids = [aws_security_group.nat_instance.id]
+
+  tags = {
+    Name = "${lookup(
+      var.nat_instance,
+      "${terraform.workspace}.name",
+      var.nat_instance["default.name"]
+    )}-1c"
+  }
+
+  iam_instance_profile = aws_iam_instance_profile.nat_instance_profile.name
+  monitoring           = true
+  source_dest_check    = false
+
+  lifecycle {
+    ignore_changes = all
+  }
+}

--- a/modules/aws/vpc/network-acl.tf
+++ b/modules/aws/vpc/network-acl.tf
@@ -1,0 +1,207 @@
+resource "aws_network_acl" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3389
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 3389
+    cidr_block = aws_vpc.vpc.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 3306
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 3306
+    cidr_block = aws_vpc.vpc.cidr_block
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  subnet_ids = [
+    aws_subnet.public_1a.id,
+    aws_subnet.public_1c.id,
+    aws_subnet.public_1d.id,
+  ]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-public"
+  }
+}
+
+resource "aws_network_acl" "private" {
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = aws_vpc.vpc.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = aws_vpc.vpc.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 22
+    cidr_block = aws_vpc.vpc.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3306
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 3306
+    cidr_block = aws_vpc.vpc.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3389
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 3389
+    cidr_block = aws_vpc.vpc.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 150
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  subnet_ids = [
+    aws_subnet.private_1a.id,
+    aws_subnet.private_1c.id,
+    aws_subnet.private_1d.id,
+  ]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-private"
+  }
+}

--- a/modules/aws/vpc/output.tf
+++ b/modules/aws/vpc/output.tf
@@ -1,0 +1,11 @@
+output "vpc" {
+  value = {
+    "vpc_id"               = aws_vpc.vpc.id
+    "subnet_public_1a_id"  = aws_subnet.public_1a.id
+    "subnet_public_1c_id"  = aws_subnet.public_1c.id
+    "subnet_public_1d_id"  = aws_subnet.public_1d.id
+    "subnet_private_1a_id" = aws_subnet.private_1a.id
+    "subnet_private_1c_id" = aws_subnet.private_1c.id
+    "subnet_private_1d_id" = aws_subnet.private_1d.id
+  }
+}

--- a/modules/aws/vpc/route-table.tf
+++ b/modules/aws/vpc/route-table.tf
@@ -1,0 +1,63 @@
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-igw"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-public-rt"
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block  = "0.0.0.0/0"
+    instance_id = aws_instance.nat_instance_1c.id
+  }
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "public_1a" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_1a.id
+}
+
+resource "aws_route_table_association" "public_1c" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_1c.id
+}
+
+resource "aws_route_table_association" "public_1d" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_1d.id
+}
+
+resource "aws_route_table_association" "private_1a" {
+  route_table_id = aws_route_table.private.id
+  subnet_id      = aws_subnet.private_1a.id
+}
+
+resource "aws_route_table_association" "private_1c" {
+  route_table_id = aws_route_table.private.id
+  subnet_id      = aws_subnet.private_1c.id
+}
+
+resource "aws_route_table_association" "private_1d" {
+  route_table_id = aws_route_table.private.id
+  subnet_id      = aws_subnet.private_1d.id
+}

--- a/modules/aws/vpc/subnet.tf
+++ b/modules/aws/vpc/subnet.tf
@@ -1,0 +1,83 @@
+resource "aws_subnet" "public_1a" {
+  vpc_id = aws_vpc.vpc.id
+  cidr_block = lookup(
+    var.vpc,
+    "${terraform.workspace}.public_1a",
+    var.vpc["default.public_1a"]
+  )
+  availability_zone = var.vpc["default.az_1a"]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-public-1a"
+  }
+}
+
+resource "aws_subnet" "public_1c" {
+  vpc_id = aws_vpc.vpc.id
+  cidr_block = lookup(
+    var.vpc,
+    "${terraform.workspace}.public_1c",
+    var.vpc["default.public_1c"]
+  )
+  availability_zone = var.vpc["default.az_1c"]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-public-1c"
+  }
+}
+
+resource "aws_subnet" "public_1d" {
+  vpc_id = aws_vpc.vpc.id
+  cidr_block = lookup(
+    var.vpc,
+    "${terraform.workspace}.public_1d",
+    var.vpc["default.public_1d"]
+  )
+  availability_zone = var.vpc["default.az_1d"]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-public-1d"
+  }
+}
+
+resource "aws_subnet" "private_1a" {
+  vpc_id = aws_vpc.vpc.id
+  cidr_block = lookup(
+    var.vpc,
+    "${terraform.workspace}.private_1a",
+    var.vpc["default.private_1a"]
+  )
+  availability_zone = var.vpc["default.az_1a"]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-private-1a"
+  }
+}
+
+resource "aws_subnet" "private_1c" {
+  vpc_id = aws_vpc.vpc.id
+  cidr_block = lookup(
+    var.vpc,
+    "${terraform.workspace}.private_1c",
+    var.vpc["default.private_1c"]
+  )
+  availability_zone = var.vpc["default.az_1c"]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-private-1c"
+  }
+}
+
+resource "aws_subnet" "private_1d" {
+  vpc_id = aws_vpc.vpc.id
+  cidr_block = lookup(
+    var.vpc,
+    "${terraform.workspace}.private_1d",
+    var.vpc["default.private_1d"]
+  )
+  availability_zone = var.vpc["default.az_1d"]
+
+  tags = {
+    Name = "${terraform.workspace}-love-psychology-private-1d"
+  }
+}

--- a/modules/aws/vpc/variable.tf
+++ b/modules/aws/vpc/variable.tf
@@ -23,3 +23,23 @@ variable "vpc" {
     "stg.private_1d"     = "10.11.12.0/24"
   }
 }
+
+variable "nat_instance" {
+  type = map(string)
+
+  default = {
+    "default.name"          = "prod-love-psychology-nat"
+    "stg.name"              = "stg-love-psychology-nat"
+    "default.ami"           = "ami-011facbea5ec0363b"
+    "default.instance_type" = "t2.micro"
+    "default.volume_type"   = "gp2"
+    "default.volume_size"   = "30"
+  }
+}
+
+// TODO AWSアカウントがステージング本番で違うので後で環境変数として渡すように改修する
+variable "ssh_public_key_path" {
+  type = string
+
+  default = "~/.ssh/stg_love_psychology_aws.pem.pub"
+}

--- a/providers/aws/environments/10-network/output.tf
+++ b/providers/aws/environments/10-network/output.tf
@@ -1,0 +1,3 @@
+output "vpc" {
+  value = module.vpc.vpc
+}

--- a/providers/aws/environments/20-bastion/backend.tf
+++ b/providers/aws/environments/20-bastion/backend.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "=0.12.19"
+
+  backend "s3" {
+    bucket  = "stg-love-psychology-tfstate"
+    key     = "bastion/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "love-psychology-stg"
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-love-psychology-tfstate"
+    key     = "env:/${terraform.workspace}/network/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "love-psychology-stg"
+  }
+}
+

--- a/providers/aws/environments/20-bastion/main.tf
+++ b/providers/aws/environments/20-bastion/main.tf
@@ -1,0 +1,4 @@
+module "bastion" {
+  source = "../../../../modules/aws/bastion"
+  vpc    = data.terraform_remote_state.network.outputs.vpc
+}

--- a/providers/aws/environments/20-bastion/output.tf
+++ b/providers/aws/environments/20-bastion/output.tf
@@ -1,0 +1,3 @@
+output "bastion" {
+  value = module.bastion.bastion
+}

--- a/providers/aws/environments/20-bastion/provider.tf
+++ b/providers/aws/environments/20-bastion/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "=2.45.0"
+  region  = "ap-northeast-1"
+  profile = "love-psychology-stg"
+}

--- a/providers/aws/environments/20-bastion/versions.tf
+++ b/providers/aws/environments/20-bastion/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform-init-stg.sh
+++ b/terraform-init-stg.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 
-cd /app/love-psychology-terraform/providers/aws/environments/10-network
+tfstateDirList='
+/app/love-psychology-terraform/providers/aws/environments/10-network
+/app/love-psychology-terraform/providers/aws/environments/20-bastion
+'
 
-pwd
-
-terraform init
-
-terraform workspace select stg
-
-terraform workspace list
+for tfstateDir in ${tfstateDirList}; do
+  echo "$tfstateDir"
+  # shellcheck disable=SC2164
+  cd "$tfstateDir"
+  pwd
+  terraform init
+  terraform workspace select stg
+  terraform workspace list
+done


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/love-psychology-terraform/issues/1

# PRのDoneの定義
- ネットワーク用のリソースが作成されている事

# 変更点概要
- VPC用リソースの作成
- SSHの踏み台Server（bastion）用リソースを作成
- 複数のtfstateを扱えるように初期化スクリプトを改修

# 補足情報
SSHキーの設定を行っておく必要がある。

SSHキーはNATインスタンスに入る時のみ利用し、普段はBastionServerも停止させておくので `Mindexer` と同様の内容を使用する。

作業用のPCで以下のように鍵をコピーしておく。

```
cp ~/.ssh/stg_qiita_stocker_aws.pem.pub ~/.ssh/stg_love_psychology_aws.pem.pub
cp ~/.ssh/stg_qiita_stocker_aws.pem ~/.ssh/stg_love_psychology_aws.pem
cp ~/.ssh/prod_qiita_stocker_aws.pem.pub ~/.ssh/prod_love_psychology_aws.pem.pub
cp ~/.ssh/prod_qiita_stocker_aws.pem ~/.ssh/prod_love_psychology_aws.pem
```

[Googleドライブ](https://drive.google.com/drive/u/2/folders/1kJnfMPKDIgCYoeSITLCg5doNTH5yrJDX) も更新済。

一時的に動作確認用のEC2インスタンスリソースを作成している。